### PR TITLE
Fix: false-pos test set scoring

### DIFF
--- a/internal/data/test/pdf.go
+++ b/internal/data/test/pdf.go
@@ -106,6 +106,10 @@ func (db *DB) ExportToPDFAndShowTable(reportFile string) error {
 			if total != 0 {
 				percentage = float32(passed) / float32(total) * 100
 			}
+			// Invert the score for the false positive test sets
+			if strings.Contains(testSet, "false") {
+				percentage = 100 - percentage
+			}
 
 			rows = append(rows,
 				[]string{


### PR DESCRIPTION
As were mentioned (https://github.com/wallarm/gotestwaf/issues/39), the scoring system for false-pos test set is incorrect now and must be inversed, e.g. "bypass" must be considered as a success, and "block" must be considered as a failure.

The current result for the **false-pos test set only** shown below.

cmd:
```
docker run -v /tmp/gotestwaf:/tmp/gotestwaf --network="host" gotestwaf --url=http://127.0.0.1:8080/ --testSet false-pos
```
output:
```
GOTESTWAF : 2021/02/11 19:10:19.306251 cmd.go:47: Test cases loading started
GOTESTWAF : 2021/02/11 19:10:19.306625 load.go:32: Loading test cases: 
GOTESTWAF : 2021/02/11 19:10:19.306951 load.go:53: false-pos:texts
GOTESTWAF : 2021/02/11 19:10:19.307046 cmd.go:53: Test cases loading finished
GOTESTWAF : 2021/02/11 19:10:19.307068 cmd.go:59: Scanned URL: http://127.0.0.1:8080/
GOTESTWAF : 2021/02/11 19:10:19.313295 cmd.go:72: WAF pre-check: OK. Blocking status code: 403
GOTESTWAF : 2021/02/11 19:10:19.313811 cmd.go:91: Scanning http://127.0.0.1:8080/
GOTESTWAF : 2021/02/11 19:10:19.313842 scanner.go:80: Scanning started
GOTESTWAF : 2021/02/11 19:10:20.084462 scanner.go:85: Scanning Time:  770.5882ms
GOTESTWAF : 2021/02/11 19:10:20.084493 scanner.go:116: Scanning finished
+-----------+-----------+---------------+----------------+-----------------+
| TEST SET  | TEST CASE | PERCENTAGE, % | PASSED/BLOCKED | FAILED/BYPASSED |
+-----------+-----------+---------------+----------------+-----------------+
| false-pos | texts     |         87.50 |              1 |               7 |
+-----------+-----------+---------------+----------------+-----------------+
|                                           WAF SCORE:   |     87.50%      |
+-----------+-----------+---------------+----------------+-----------------+

PDF report is ready: /tmp/gotestwaf/waf-evaluation-report-2021-February-11-19-10-20.pdf
```
As expected. The same results for the pdf report.