### PR TITLE
Add Windows support

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -114,6 +114,9 @@ func Run() int {
 }
 
 func parseFlags() {
+	defaultReportDir := filepath.Join(os.TempDir(), "gotestwaf")
+	defaultTestCasesPath := filepath.Join(".", "testcases")
+
 	flag.StringVar(&configPath, "configPath", "config.yaml", "Path to a config file")
 	flag.BoolVar(&verbose, "verbose", true, "If true, enable verbose logging")
 
@@ -136,9 +139,9 @@ func parseFlags() {
 	flag.Int("sendDelay", 400, "Delay in ms between requests")
 	flag.Int("randomDelay", 400, "Random delay in ms in addition to the delay between requests")
 	flag.String("testCase", "", "If set then only this test case will be run")
-	flag.String("testCasesPath", "./testcases/", "Path to a folder with test cases")
+	flag.String("testCasesPath", defaultTestCasesPath, "Path to a folder with test cases")
 	flag.String("testSet", "", "If set then only this test set's cases will be run")
-	flag.String("reportDir", "/tmp/gotestwaf/", "A directory to store reports")
+	flag.String("reportDir", defaultReportDir, "A directory to store reports")
 
 	flag.Parse()
 }

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -12,6 +12,7 @@ import (
 
 	flag "github.com/spf13/pflag"
 	"github.com/spf13/viper"
+
 	"github.com/wallarm/gotestwaf/internal/data/config"
 	"github.com/wallarm/gotestwaf/internal/data/test"
 	"github.com/wallarm/gotestwaf/internal/scanner"

--- a/internal/data/test/load.go
+++ b/internal/data/test/load.go
@@ -36,7 +36,7 @@ func Load(cfg *config.Config, logger *log.Logger) ([]Case, error) {
 		}
 
 		// Ignore subdirectories, process as .../<testSetName>/<testCaseName>/<case>.yml
-		parts := strings.Split(testCaseFile, "/")
+		parts := strings.Split(testCaseFile, string(os.PathSeparator))
 		parts = parts[len(parts)-3:]
 
 		testSetName := parts[1]

--- a/internal/data/test/load.go
+++ b/internal/data/test/load.go
@@ -8,8 +8,9 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"github.com/wallarm/gotestwaf/internal/data/config"
 	"gopkg.in/yaml.v2"
+
+	"github.com/wallarm/gotestwaf/internal/data/config"
 )
 
 const testCaseExt = ".yml"

--- a/internal/scanner/http_client.go
+++ b/internal/scanner/http_client.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
 	"github.com/wallarm/gotestwaf/internal/data/config"
 	"github.com/wallarm/gotestwaf/internal/payload/encoder"
 	"github.com/wallarm/gotestwaf/internal/payload/placeholder"

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
 	"github.com/wallarm/gotestwaf/internal/data/config"
 	"github.com/wallarm/gotestwaf/internal/data/test"
 	"github.com/wallarm/gotestwaf/internal/payload/encoder"


### PR DESCRIPTION
In this PR some paths specific to unix-like systems have been replaced with dynamically computed default paths that depend on the host system. This allows us to run gotestwaf directly on Windows without docker.

Closes #30 