### PR TITLE
Update reports save path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 gotestwaf
 main
 *.pdf
+reports/waf*
 chromedp/*
 .idea
 .DS_store

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-reports
 gotestwaf
 main
 *.pdf

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+reports
 gotestwaf
 main
 *.pdf

--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Like URL parameter, URI, POST form parameter, or JSON POST body.
 # Quick start
 ```
 docker build . --force-rm -t gotestwaf
-docker run -v /tmp:/tmp/gotestwaf gotestwaf --url=https://the-waf-you-wanna-test/
+docker run -v ${PWD}:/go/src/gotestwaf/reports gotestwaf --url=https://the-waf-you-wanna-test/
 ```
 
-Find the report file waf-test-report-<date>.pdf in a /tmp folder you mapped to /tmp/report inside the container.
+Find the report file `waf-test-report-<date>.pdf` in a current folder that you mapped to `/go/src/gotestwaf/reports` inside the container.
 
 # Examples
 
@@ -47,7 +47,7 @@ You may choose the PARANOIA level to increase the level of security.
 Learn more https://coreruleset.org/faq/
 
 #### Run gotestwaf
-`docker run -v /tmp:/tmp/gotestwaf gotestwaf --url=http://the-waf-you-wanna-test/`
+`docker run -v ${PWD}:/go/src/gotestwaf/reports gotestwaf --url=http://the-waf-you-wanna-test/`
 
 #### Check results
 ```

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Like URL parameter, URI, POST form parameter, or JSON POST body.
 # Quick start
 ```
 docker build . --force-rm -t gotestwaf
-docker run -v ${PWD}:/go/src/gotestwaf/reports gotestwaf --url=https://the-waf-you-wanna-test/
+docker run -v ${PWD}/reports:/go/src/gotestwaf/reports gotestwaf --url=https://the-waf-you-wanna-test/
 ```
 
 Find the report file `waf-test-report-<date>.pdf` in a current folder that you mapped to `/go/src/gotestwaf/reports` inside the container.
@@ -47,7 +47,7 @@ You may choose the PARANOIA level to increase the level of security.
 Learn more https://coreruleset.org/faq/
 
 #### Run gotestwaf
-`docker run -v ${PWD}:/go/src/gotestwaf/reports gotestwaf --url=http://the-waf-you-wanna-test/`
+`docker run -v ${PWD}/reports:/go/src/gotestwaf/reports gotestwaf --url=http://the-waf-you-wanna-test/`
 
 #### Check results
 ```

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -115,7 +115,7 @@ func Run() int {
 }
 
 func parseFlags() {
-	defaultReportDir := filepath.Join(os.TempDir(), "gotestwaf")
+	defaultReportDir := filepath.Join(".", "reports")
 	defaultTestCasesPath := filepath.Join(".", "testcases")
 
 	flag.StringVar(&configPath, "configPath", "config.yaml", "Path to a config file")

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -21,6 +21,8 @@ import (
 const (
 	reportPrefix  = "waf-evaluation-report"
 	payloadPrefix = "waf-evaluation-payloads"
+	reportsDir = "reports"
+	testCasesDir = "testcases"
 )
 
 var (
@@ -115,8 +117,8 @@ func Run() int {
 }
 
 func parseFlags() {
-	defaultReportDir := filepath.Join(".", "reports")
-	defaultTestCasesPath := filepath.Join(".", "testcases")
+	defaultReportDir := filepath.Join(".", reportsDir)
+	defaultTestCasesPath := filepath.Join(".", testCasesDir)
 
 	flag.StringVar(&configPath, "configPath", "config.yaml", "Path to a config file")
 	flag.BoolVar(&verbose, "verbose", true, "If true, enable verbose logging")


### PR DESCRIPTION
Now all the files related to the reports are saving in the `./reports` directory (relative to the current running path on a local system or inside a container). Documentation for docker also updated:

1. Container path updated from `/tmp/gotestwaf` to `/go/src/gotestwaf/reports`
2. Mapping to local system path updated from `/tmp` to `${PWD}` (current path)