### PR TITLE
Add date and WAF name

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"net/url"
@@ -20,6 +21,7 @@ import (
 )
 
 const (
+	wafName       = "generic"
 	reportPrefix  = "waf-evaluation-report"
 	payloadPrefix = "waf-evaluation-payloads"
 	reportsDir    = "reports"
@@ -137,16 +139,17 @@ func Run() int {
 		return 1
 	}
 
-	reportTime := time.Now().Format("2006-January-02-15-04-05")
+	reportTime := time.Now()
+	reportSaveTime := reportTime.Format("2006-January-02-15-04-05")
 
-	reportFile := filepath.Join(cfg.ReportDir, reportPrefix+"-"+reportTime+".pdf")
-	err = db.ExportToPDFAndShowTable(reportFile)
+	reportFile := filepath.Join(cfg.ReportDir, fmt.Sprintf("%s-%s-%s.pdf", reportPrefix, cfg.WAFName, reportSaveTime))
+	err = db.ExportToPDFAndShowTable(reportFile, reportTime, cfg.WAFName)
 	if err != nil {
 		logger.Println("exporting report:", err)
 		return 1
 	}
 
-	payloadFiles := filepath.Join(cfg.ReportDir, payloadPrefix+"-"+reportTime+".csv")
+	payloadFiles := filepath.Join(cfg.ReportDir, fmt.Sprintf("%s-%s-%s.csv", payloadPrefix, cfg.WAFName, reportSaveTime))
 	err = db.ExportPayloads(payloadFiles)
 	if err != nil {
 		logger.Println("exporting payloads:", err)
@@ -185,7 +188,7 @@ func parseFlags() {
 	flag.String("testCasesPath", defaultTestCasesPath, "Path to a folder with test cases")
 	flag.String("testSet", "", "If set then only this test set's cases will be run")
 	flag.String("reportDir", defaultReportDir, "A directory to store reports")
-
+	flag.String("wafName", wafName, "Name of the WAF product")
 	flag.Parse()
 }
 

--- a/internal/data/config/config.go
+++ b/internal/data/config/config.go
@@ -25,4 +25,5 @@ type Config struct {
 	TestCase           string            `mapstructure:"testCase"`
 	TestCasesPath      string            `mapstructure:"testCasesPath"`
 	TestSet            string            `mapstructure:"testSet"`
+	WAFName            string            `mapstructure:"wafName"`
 }


### PR DESCRIPTION
This PR adds the following features:
1. Name of the WAF solution now can be configured by a user (with CLI flag), default name - "generic"
2. Date of the test and name of the WAF are now displayed in the CLI table
3. Also date and name of the WAF available via the PDF report
4. Filenames now include the name of the WAF too