### PR TITLE
Update PDF report, improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ gotestwaf:
 	docker build . --force-rm -t gotestwaf
 
 scan_local:
-	docker run -v ${PWD}/reports:/go/src/gotestwaf/reports --network="host" gotestwaf --url=http://127.0.0.1:8080/
+	docker run -v ${PWD}/reports:/go/src/gotestwaf/reports --network="host" gotestwaf --url=http://127.0.0.1:8080/ --verbose
 
 lint:
 	golangci-lint -v run ./...

--- a/README.md
+++ b/README.md
@@ -24,7 +24,13 @@ A place inside HTTP request where encoded payload should be.
 Like URL parameter, URI, POST form parameter, or JSON POST body.
 
 # Quick start
-## Docker
+## Dockerhub
+The latest gotestwaf always available via the dockerhub repository: https://hub.docker.com/r/wallarm/gotestwaf  
+It can be easily pulled via the following command:  
+```
+docker pull wallarm/gotestwaf
+```
+## Local Docker build
 ```
 docker build . --force-rm -t gotestwaf
 docker run -v ${PWD}/reports:/go/src/gotestwaf/reports gotestwaf --url=https://the-waf-you-wanna-test/
@@ -55,34 +61,19 @@ Learn more https://coreruleset.org/faq/
 #### Run gotestwaf
 `docker run -v ${PWD}/reports:/go/src/gotestwaf/reports gotestwaf --url=http://172.17.0.1:8080/`
 
+#### Run gotestwaf with WebSocket check
+You can additionally set the WebSocket URL to check via the `wsURL` flag and `verbose` flag to include more information about the checking process:  
+`docker run -v ${PWD}/reports:/go/src/gotestwaf/reports gotestwaf --url=http://172.17.0.1:8080/ --wsURL=ws://172.17.0.1:8080/api/ws --verbose`
+
+
 #### Check results
 ```
 GOTESTWAF : 2021/02/25 02:54:04.782526 cmd.go:66: Test cases loading started
-GOTESTWAF : 2021/02/25 02:54:04.782738 load.go:33: Loading test cases: 
-GOTESTWAF : 2021/02/25 02:54:04.782750 load.go:54: community:community-lfi
-GOTESTWAF : 2021/02/25 02:54:04.782797 load.go:54: community:community-rce
-GOTESTWAF : 2021/02/25 02:54:04.782874 load.go:54: community:community-sqli
-GOTESTWAF : 2021/02/25 02:54:04.782976 load.go:54: community:community-xss
-GOTESTWAF : 2021/02/25 02:54:04.783366 load.go:54: community:community-xxe
-GOTESTWAF : 2021/02/25 02:54:04.783413 load.go:54: false-pos:texts
-GOTESTWAF : 2021/02/25 02:54:04.783460 load.go:54: owasp:ldap-injection
-GOTESTWAF : 2021/02/25 02:54:04.783503 load.go:54: owasp:mail-injection
-GOTESTWAF : 2021/02/25 02:54:04.783541 load.go:54: owasp:nosql-injection
-GOTESTWAF : 2021/02/25 02:54:04.783587 load.go:54: owasp:path-traversal
-GOTESTWAF : 2021/02/25 02:54:04.783628 load.go:54: owasp:shell-injection
-GOTESTWAF : 2021/02/25 02:54:04.783671 load.go:54: owasp:sql-injection
-GOTESTWAF : 2021/02/25 02:54:04.783712 load.go:54: owasp:ss-include
-GOTESTWAF : 2021/02/25 02:54:04.783758 load.go:54: owasp:sst-injection
-GOTESTWAF : 2021/02/25 02:54:04.783806 load.go:54: owasp:xml-injection
-GOTESTWAF : 2021/02/25 02:54:04.783867 load.go:54: owasp:xss-scripting
-GOTESTWAF : 2021/02/25 02:54:04.783922 load.go:54: owasp-api:graphql
-GOTESTWAF : 2021/02/25 02:54:04.783965 load.go:54: owasp-api:rest
-GOTESTWAF : 2021/02/25 02:54:04.783997 load.go:54: owasp-api:soap
 GOTESTWAF : 2021/02/25 02:54:04.784032 cmd.go:72: Test cases loading finished
 GOTESTWAF : 2021/02/25 02:54:04.784050 cmd.go:78: Scanned URL: http://172.17.0.1:8080/
 GOTESTWAF : 2021/02/25 02:54:04.788380 cmd.go:91: WAF pre-check: OK. Blocking status code: 403
-GOTESTWAF : 2021/02/25 02:54:04.788397 cmd.go:102: WebSocket URL to check: ws://172.17.0.1:8080/
-GOTESTWAF : 2021/02/25 02:54:04.791253 cmd.go:106: WebSocket connection is not available, reason: websocket: bad handshake
+GOTESTWAF : 2021/02/25 02:54:04.788397 cmd.go:102: WebSocket pre-check. URL to check: ws://172.17.0.1:8080/api/ws
+GOTESTWAF : 2021/02/25 02:54:04.791253 cmd.go:106: WebSocket pre-check: connection is not available, reason: websocket: bad handshake
 GOTESTWAF : 2021/02/25 02:54:04.791354 cmd.go:135: Scanning http://172.17.0.1:8080/
 GOTESTWAF : 2021/02/25 02:54:04.791373 scanner.go:124: Scanning started
 GOTESTWAF : 2021/02/25 02:54:07.268681 scanner.go:129: Scanning Time:  2.477299327s
@@ -160,6 +151,8 @@ Usage of /go/src/gotestwaf/gotestwaf:
         URL to check (default "http://localhost/")
   --verbose                
         If true, enable verbose logging (default true)
+  --wafName string
+        Name of the WAF product (default "generic")
   --workers int
         The number of workers to scan (default 200)
   --wsURL string

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -163,7 +163,7 @@ func parseFlags() {
 	defaultTestCasesPath := filepath.Join(".", testCasesDir)
 
 	flag.StringVar(&configPath, "configPath", "config.yaml", "Path to a config file")
-	flag.BoolVar(&verbose, "verbose", false, "If true, enable verbose logging")
+	flag.BoolVar(&verbose, "verbose", true, "If true, enable verbose logging")
 
 	flag.String("url", "http://localhost/", "URL to check")
 	flag.String("wsURL", "", "WebSocket URL to check")

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -99,11 +99,11 @@ func Run() int {
 		cfg.WebSocketURL = wsUrl
 	}
 
-	logger.Printf("WebSocket URL to check: %s\n", cfg.WebSocketURL)
+	logger.Printf("WebSocket pre-check. URL to check: %s\n", cfg.WebSocketURL)
 
 	available, blocked, err := s.WSPreCheck(cfg.WebSocketURL)
 	if !available && err != nil {
-		logger.Printf("WebSocket connection is not available, "+
+		logger.Printf("WebSocket pre-check: connection is not available, "+
 			"reason: %s\n", err)
 	}
 	if available && blocked {
@@ -163,7 +163,7 @@ func parseFlags() {
 	defaultTestCasesPath := filepath.Join(".", testCasesDir)
 
 	flag.StringVar(&configPath, "configPath", "config.yaml", "Path to a config file")
-	flag.BoolVar(&verbose, "verbose", true, "If true, enable verbose logging")
+	flag.BoolVar(&verbose, "verbose", false, "If true, enable verbose logging")
 
 	flag.String("url", "http://localhost/", "URL to check")
 	flag.String("wsURL", "", "WebSocket URL to check")

--- a/internal/data/test/load.go
+++ b/internal/data/test/load.go
@@ -30,7 +30,6 @@ func Load(cfg *config.Config, logger *log.Logger) ([]Case, error) {
 		return nil, err
 	}
 
-	logger.Println("Loading test cases: ")
 	for _, testCaseFile := range files {
 		if filepath.Ext(testCaseFile) != testCaseExt {
 			continue
@@ -50,8 +49,6 @@ func Load(cfg *config.Config, logger *log.Logger) ([]Case, error) {
 		if cfg.TestCase != "" && testCaseName != cfg.TestCase {
 			continue
 		}
-
-		logger.Printf("%v:%v", testSetName, testCaseName)
 
 		yamlFile, err := ioutil.ReadFile(testCaseFile)
 		if err != nil {

--- a/internal/data/test/pdf.go
+++ b/internal/data/test/pdf.go
@@ -246,12 +246,12 @@ func (db *DB) ExportToPDFAndShowTable(reportFile string, reportTime time.Time, W
 
 	pdf.Ln(lineBreakSize)
 
-	// Include only real bypasses, without unknown or false pos/true pos
-	bypassesNum := len(rowsPayloads) - 1
-	blockedNum := len(db.passedTests)
 	// Num = number of actual rows - top header (1 line)
 	truePosNum := len(rowsTruePos) - 1
 	falsePosNum := len(rowsFalsePos) - 1
+	// Include only real bypasses, without unknown or false pos/true pos
+	bypassesNum := len(rowsPayloads) - 1
+	blockedNum := len(db.passedTests) - truePosNum
 	currentY := pdf.GetY()
 
 	chartBuf, err := drawChart(bypassesNum, blockedNum, bypassesNum+blockedNum, "Bypassed", "Blocked")

--- a/internal/data/test/pdf.go
+++ b/internal/data/test/pdf.go
@@ -83,7 +83,7 @@ func tableClip(pdf *gofpdf.Fpdf, cols []float64, rows [][]string, fontSize float
 	}
 }
 
-func drawChart(bypassed int, blocked int, overall int) (*bytes.Buffer, error) {
+func drawChart(bypassed int, blocked int, overall int, failed string, passed string) (*bytes.Buffer, error) {
 	bypassedProc := float64(bypassed*100) / float64(overall)
 	blockedProc := 100.0 - bypassedProc
 	pie := chart.PieChart{
@@ -92,14 +92,14 @@ func drawChart(bypassed int, blocked int, overall int) (*bytes.Buffer, error) {
 		Values: []chart.Value{
 			{
 				Value: float64(bypassed),
-				Label: fmt.Sprintf("Bypassed (%.2f%%)", bypassedProc),
+				Label: fmt.Sprintf("%s (%d payloads, %.2f%%)", failed, bypassed, bypassedProc),
 				Style: chart.Style{
 					FillColor: drawing.ColorFromAlphaMixedRGBA(234, 67, 54, 255),
 				},
 			},
 			{
 				Value: float64(blocked),
-				Label: fmt.Sprintf("Blocked (%.2f%%)", blockedProc),
+				Label: fmt.Sprintf("%s (%d payloads, %.2f%%)", passed, blocked, blockedProc),
 				Style: chart.Style{
 					FillColor: drawing.ColorFromAlphaMixedRGBA(66, 133, 244, 255),
 				},
@@ -193,23 +193,88 @@ func (db *DB) ExportToPDFAndShowTable(reportFile string, reportTime time.Time, W
 	pdf.Ln(lineBreakSize / 2)
 	pdf.Cell(cellWidth, cellHeight, fmt.Sprintf("WAF testing date: %s", reportPdfTime))
 	pdf.Ln(lineBreakSize)
-	pdf.Cell(cellWidth, cellHeight, fmt.Sprintf("%v bypasses in %v tests / %v test cases",
-		overallTestsFailed, overallTestsCompleted, overallTestcasesCompleted))
+
+	// Num of bypasses = failed tests + true positive (bypassed false pos) - NA tests (unknown results)
+	// Or, in other words, num of bypasses = correct malicious bypasses only + true positive
+	pdf.Cell(cellWidth, cellHeight, fmt.Sprintf("%v bypasses in %v tests, %v unresolved cases / %v test cases",
+		overallTestsFailed-len(db.naTests), overallTestsCompleted, len(db.naTests), overallTestcasesCompleted))
 	pdf.Ln(lineBreakSize)
 
 	tableClip(pdf, cols, rows, 12)
 
+	cols = []float64{100, 30, 20, 25, 15}
+	rows = [][]string{}
+	var rowsTruePos [][]string
+	var rowsFalsePos [][]string
+
+	rows = append(rows, []string{"Payload", "Test Case", "Encoder", "Placeholder", "Status"})
+	// True positive  - false positive payloads that bypass the WAF (good behavior)
+	rowsTruePos = append(rowsTruePos, []string{"Payload", "Test Case", "Encoder", "Placeholder", "Status"})
+	// False positive - false positive payloads that were blocked (bad behavior)
+	rowsFalsePos = append(rowsFalsePos, []string{"Payload", "Test Case", "Encoder", "Placeholder", "Status"})
+
+	for _, failedTest := range db.failedTests {
+		payload := fmt.Sprintf("%+q", failedTest.Payload)
+		payload = strings.ReplaceAll(payload[1:len(payload)-1], `\"`, `"`)
+		toAppend := []string{payload,
+			failedTest.Case,
+			failedTest.Encoder,
+			failedTest.Placeholder,
+			strconv.Itoa(failedTest.ResponseStatusCode)}
+		// Failed for false pos - blocked by the waf, bad behavior
+		if strings.Contains(failedTest.Set, "false") {
+			rowsFalsePos = append(rowsFalsePos, toAppend)
+		} else {
+			rows = append(rows, toAppend)
+		}
+	}
+
+	for _, blockedTest := range db.passedTests {
+		payload := fmt.Sprintf("%+q", blockedTest.Payload)
+		payload = strings.ReplaceAll(payload[1:len(payload)-1], `\"`, `"`)
+		toAppend := []string{payload,
+			blockedTest.Case,
+			blockedTest.Encoder,
+			blockedTest.Placeholder,
+			strconv.Itoa(blockedTest.ResponseStatusCode)}
+		// Passed for false pos - bypassed, good behavior
+		if strings.Contains(blockedTest.Set, "false") {
+			rowsTruePos = append(rowsTruePos, toAppend)
+		}
+	}
+
 	pdf.Ln(lineBreakSize)
-	chartBuf, err := drawChart(overallTestsFailed, overallTestsCompleted-overallTestsFailed, overallTestsCompleted)
+
+	// Include only failed tests (without Unknown)
+	bypassesNum := len(db.failedTests)
+	blockedNum := len(db.passedTests)
+	// Num = number of actual rows - top header (1 line)
+	truePosNum := len(rowsTruePos) - 1
+	falsePosNum := len(rowsFalsePos) - 1
+	currentY := pdf.GetY()
+
+	chartBuf, err := drawChart(bypassesNum, blockedNum, bypassesNum+blockedNum, "Bypassed", "Blocked")
 	if err != nil {
 		return errors.Wrap(err, "Plot generation error")
 	}
-	imageInfo := pdf.RegisterImageReader("", "PNG", chartBuf)
+	imageInfo := pdf.RegisterImageReader("Overall Plot", "PNG", chartBuf)
 	if pdf.Ok() {
 		imgWd, imgHt := imageInfo.Extent()
 		imgWd, imgHt = imgWd/2, imgHt/2
-		pdf.Image("", (pageWidth-imgWd)/2, (pageHeight-imgHt)/2,
-			imgWd, imgHt, true, "PNG", 0, "")
+		pdf.Image("Overall Plot", pageWidth/20, currentY,
+			imgWd, imgHt, false, "PNG", 0, "")
+	}
+
+	chartFalseBuf, err := drawChart(falsePosNum, truePosNum, truePosNum+falsePosNum, "False Positive", "True Positive")
+	if err != nil {
+		return errors.Wrap(err, "Plot generation error")
+	}
+	imageInfoFalse := pdf.RegisterImageReader("False Pos Plot", "PNG", chartFalseBuf)
+	if pdf.Ok() {
+		imgWd, imgHt := imageInfoFalse.Extent()
+		imgWd, imgHt = imgWd/2, imgHt/2
+		pdf.Image("False Pos Plot", pageWidth-imgWd-pageWidth/20, currentY,
+			imgWd, imgHt, false, "PNG", 0, "")
 	}
 
 	httpimg.Register(pdf, trollLink, "")
@@ -217,30 +282,37 @@ func (db *DB) ExportToPDFAndShowTable(reportFile string, reportTime time.Time, W
 
 	pdf.AddPage()
 
-	cols = []float64{100, 30, 20, 25, 15}
-	rows = [][]string{}
-
-	rows = append(rows, []string{"Payload", "Test Case", "Encoder", "Placeholder", "Status"})
-	for _, failedTest := range db.failedTests {
-		payload := fmt.Sprintf("%+q", failedTest.Payload)
-		payload = strings.ReplaceAll(payload[1:len(payload)-1], `\"`, `"`)
-		rows = append(rows,
-			[]string{payload,
-				failedTest.Case,
-				failedTest.Encoder,
-				failedTest.Placeholder,
-				strconv.Itoa(failedTest.ResponseStatusCode)},
-		)
-	}
+	// Malicious payloads block
 	pdf.SetFont("Arial", "", 24)
-	pdf.Cell(cellWidth, cellHeight, "Bypasses in details.")
+	pdf.Cell(cellWidth, cellHeight, "Bypasses in Details")
 	pdf.Ln(lineBreakSize)
 	pdf.SetFont("Arial", "", 12)
-	pdf.Cell(cellWidth, cellHeight, fmt.Sprintf("\n%d malicious requests have bypassed the WAF", len(db.failedTests)))
+	pdf.Cell(cellWidth, cellHeight, fmt.Sprintf("\n%d malicious requests have bypassed the WAF", len(rows)-1))
 	pdf.Ln(lineBreakSize)
 	pdf.SetFont("Arial", "", 10)
 
 	tableClip(pdf, cols, rows, 10)
+
+	pdf.AddPage()
+	pdf.SetFont("Arial", "", 24)
+	pdf.Cell(cellWidth, cellHeight, "False Positive and True Positive in Details")
+	pdf.Ln(lineBreakSize)
+
+	// False Positive payloads block
+	pdf.SetFont("Arial", "", 12)
+	pdf.Cell(cellWidth, cellHeight, fmt.Sprintf("\n%d false positive requests identified as blocked (failed, bad behavior)", len(rowsFalsePos)-1))
+	pdf.Ln(lineBreakSize)
+	pdf.SetFont("Arial", "", 10)
+
+	tableClip(pdf, cols, rowsFalsePos, 10)
+
+	// True Positive payloads block
+	pdf.SetFont("Arial", "", 12)
+	pdf.Cell(cellWidth, cellHeight, fmt.Sprintf("\n%d true positive requests identified as bypassed (passed, good behavior)", len(rowsTruePos)-1))
+	pdf.Ln(lineBreakSize)
+	pdf.SetFont("Arial", "", 10)
+
+	tableClip(pdf, cols, rowsTruePos, 10)
 
 	pdf.AddPage()
 
@@ -260,7 +332,7 @@ func (db *DB) ExportToPDFAndShowTable(reportFile string, reportTime time.Time, W
 		)
 	}
 	pdf.SetFont("Arial", "", 24)
-	pdf.Cell(cellWidth, cellHeight, "Unresolved test cases")
+	pdf.Cell(cellWidth, cellHeight, "Unresolved Test Cases")
 	pdf.Ln(lineBreakSize)
 	pdf.SetFont("Arial", "", 12)
 	pdf.Cell(cellWidth, cellHeight, fmt.Sprintf("\n%d requests indentified as blocked and passed or as not-blocked and not-passed",


### PR DESCRIPTION
This PR includes:
1. Useless logging deleted (testcases loading, etc.)
2. README updated (includes information about dockerhub, WebSockets testing)
3. Big PDF report update: calculations, logic and plots were improved

An example of the report can be seen here:
[waf-evaluation-report-generic-2021-February-25-07-05-25.pdf](https://github.com/wallarm/gotestwaf/files/6041092/waf-evaluation-report-generic-2021-February-25-07-05-25.pdf)

You can check the correctness:
386 (blocked) + 86 (bypassed) + 1 (true positive) + 7 (false positive) + 119 (unresolved cases) = 599 (overall cases)