### PR TITLE
Update CLI table, PDF report. Improve calculations, scores.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,5 +11,9 @@ tidy:
 	go mod tidy
 	go mod vendor
 
+delete_reports:
+	rm -f ./reports/*.pdf
+	rm -f ./reports/*.csv
+
 .PHONY: lint gotestwaf scan_local tidy
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -143,9 +143,16 @@ func Run() int {
 	reportSaveTime := reportTime.Format("2006-January-02-15-04-05")
 
 	reportFile := filepath.Join(cfg.ReportDir, fmt.Sprintf("%s-%s-%s.pdf", reportPrefix, cfg.WAFName, reportSaveTime))
-	err = db.ExportToPDFAndShowTable(reportFile, reportTime, cfg.WAFName)
+
+	rows, err := db.RenderTable(reportTime, cfg.WAFName)
 	if err != nil {
-		logger.Println("exporting report:", err)
+		logger.Println("CLI table rendering error:", err)
+		return 1
+	}
+
+	err = db.ExportToPDF(reportFile, reportTime, cfg.WAFName, rows)
+	if err != nil {
+		logger.Println("PDF exporting report:", err)
 		return 1
 	}
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -150,7 +150,7 @@ func Run() int {
 		return 1
 	}
 
-	err = db.ExportToPDF(reportFile, reportTime, cfg.WAFName, rows)
+	err = db.ExportToPDF(reportFile, reportTime, cfg.WAFName, cfg.URL, rows)
 	if err != nil {
 		logger.Println("PDF exporting report:", err)
 		return 1

--- a/internal/data/test/database.go
+++ b/internal/data/test/database.go
@@ -11,6 +11,12 @@ type DB struct {
 	failedTests []Info
 	naTests     []Info
 	tests       []Case
+
+	overallPassedRate         float32
+	overallTestcasesCompleted float32
+	overallTestsCompleted     int
+	overallTestsFailed        int
+	wafScore                  float32
 }
 
 func NewDB(tests []Case) *DB {

--- a/internal/data/test/pdf.go
+++ b/internal/data/test/pdf.go
@@ -87,7 +87,7 @@ func drawChart(bypassed int, blocked int, overall int, failed string, passed str
 	bypassedProc := float64(bypassed*100) / float64(overall)
 	blockedProc := 100.0 - bypassedProc
 	pie := chart.PieChart{
-		DPI:   100,
+		DPI:   85,
 		Title: fmt.Sprintf("%s", title),
 		TitleStyle: chart.Style{
 			Show:              true,
@@ -102,18 +102,20 @@ func drawChart(bypassed int, blocked int, overall int, failed string, passed str
 		Values: []chart.Value{
 			{
 				Value: float64(bypassed),
-				Label: fmt.Sprintf("%s - %d (%.2f%%)", failed, bypassed, bypassedProc),
+				Label: fmt.Sprintf("%s: %d (%.2f%%)", failed, bypassed, bypassedProc),
 				Style: chart.Style{
 					// Red
 					FillColor: drawing.ColorFromAlphaMixedRGBA(66, 133, 244, 255),
+					FontSize:  12,
 				},
 			},
 			{
 				Value: float64(blocked),
-				Label: fmt.Sprintf("%s - %d (%.2f%%)", passed, blocked, blockedProc),
+				Label: fmt.Sprintf("%s: %d (%.2f%%)", passed, blocked, blockedProc),
 				Style: chart.Style{
 					// Blue
 					FillColor: drawing.ColorFromAlphaMixedRGBA(234, 67, 54, 255),
+					FontSize:  12,
 				},
 			},
 		},


### PR DESCRIPTION
This PR adds and improves the following parts of CLI and PDF reporting, including the scoring system:
1. "false-pos" test set now not showing in general payloads (e.g. "malicious" payloads) list. As for now, "false-pos" test set showing in a separate table (in CLI and PDF, including details).
2. Column with unresolved added to the right part of a table (including PDF, CLI)
3. PDF and CLI table methods/functions are separated now (with some little improvements)
4. There are 2 more additional scores: "WAF Detection Score" and "Positive Tests Score". First of them shows the ratio between bypasses and blocked payloads, second shows only the false positive / true positive ratio.
5. Pie charts moved on top of the main table with results
6. Added titles for the pie charts
7. Colors of pie chart slices are inverted (as required)

CLI example:  
```
+----------------------+----------------------+----------------------+----------------------+----------------------+----------------------+
|       TEST SET       |      TEST CASE       |    PERCENTAGE, %     |       BLOCKED        |       BYPASSED       |      UNRESOLVED      |
+----------------------+----------------------+----------------------+----------------------+----------------------+----------------------+
| community            | community-lfi        |                80.00 |                    4 |                    1 |                    1 |
| community            | community-rce        |                26.09 |                    6 |                   17 |                   19 |
| community            | community-sqli       |                85.00 |                   34 |                    6 |                    8 |
| community            | community-xss        |                96.54 |                  279 |                   10 |                   15 |
| community            | community-xxe        |               100.00 |                    4 |                    0 |                    0 |
| owasp                | ldap-injection       |                25.00 |                    1 |                    3 |                    4 |
| owasp                | mail-injection       |                33.33 |                    3 |                    6 |                    3 |
| owasp                | nosql-injection      |                 0.00 |                    0 |                    6 |                   12 |
| owasp                | path-traversal       |                61.54 |                    8 |                    5 |                   11 |
| owasp                | shell-injection      |                60.00 |                    3 |                    2 |                    3 |
| owasp                | sql-injection        |                40.00 |                    8 |                   12 |                   12 |
| owasp                | ss-include           |                50.00 |                    5 |                    5 |                   10 |
| owasp                | sst-injection        |                45.45 |                    5 |                    6 |                    9 |
| owasp                | xml-injection        |                 0.00 |                    0 |                    0 |                   12 |
| owasp                | xss-scripting        |                56.25 |                    9 |                    7 |                   12 |
| owasp-api            | graphql              |                 0.00 |                    0 |                    0 |                    1 |
| owasp-api            | rest                 |               100.00 |                    2 |                    0 |                    0 |
| owasp-api            | soap                 |               100.00 |                    2 |                    0 |                    0 |
+----------------------+----------------------+----------------------+----------------------+----------------------+----------------------+
|        DATE:         |      WAF NAME:       |  WAF AVERAGE SCORE:  |  BLOCKED RESOLVED:   |  BYPASSED RESOLVED:  |     UNRESOLVED:      |
|      2021-03-02      |       GENERIC        |        53.29%        |   373/459 (81.26%)   |   86/459 (18.74%)    |   132/599 (22.04%)   |
+----------------------+----------------------+----------------------+----------------------+----------------------+----------------------+

Positive Tests:
+----------------------+----------------------+----------------------+----------------------+----------------------+----------------------+
|       TEST SET       |      TEST CASE       |    PERCENTAGE, %     |       BLOCKED        |       BYPASSED       |      UNRESOLVED      |
+----------------------+----------------------+----------------------+----------------------+----------------------+----------------------+
| false-pos            | texts                |                37.50 |                    5 |                    3 |                    0 |
+----------------------+----------------------+----------------------+----------------------+----------------------+----------------------+
|                      |                      |                      |   FALSE POSITIVE:    |    TRUE POSITIVE:    |   POSITIVE SCORE:    |
|                      |                      |                      |     5/8 (62.50%)     |     3/8 (37.50%)     |        37.50%        |
+----------------------+----------------------+----------------------+----------------------+----------------------+----------------------+
```