### PR TITLE
URL Encode false positive payloads

### DIFF
--- a/testcases/false-pos/texts.yml
+++ b/testcases/false-pos/texts.yml
@@ -8,6 +8,6 @@ payload:
   - 'The Senora found herself a heroine; more than that, she became aware'
   - time he came.
 encoder:
-  - Plain
+  - URL
 placeholder:
   - URLParam


### PR DESCRIPTION
This PR fixes URL params encoding problem with false-pos payloads. Now params are not "plain", but "URL" to apply URL encoder for them.

@dnkolegov please, check that this solution and the related fix is correct in terms of expected general logic/behavior