### PR TITLE
Update "Not Detected" message information. Provide flags info.

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -78,7 +78,7 @@ func run(logger *log.Logger) error {
 	}
 	if !ok {
 		return errors.Errorf("WAF was not detected. "+
-			"Please check the 'block_statuscode' or 'block_regexp' values."+
+			"Please use the '--blockStatusCode' or '--blockRegex' flags. Use '--help' for additional info."+
 			"\nBaseline attack status code: %v\n", httpStatus)
 	}
 


### PR DESCRIPTION
This PR provides more information in case when WAF was not detected. Also, flag names fixed to match the usage information (`--help` info).

Before:
```
GOTESTWAF : 2021/03/20 01:28:16.826232 main.go:42: main error: WAF was not detected. Please check the 'block_statuscode' or 'block_regexp' values.
```

Now:
```
GOTESTWAF : 2021/03/22 22:28:13.201614 main.go:42: main error: WAF was not detected. Please use the '--blockStatusCode' or '--blockRegex' flags. Use '--help' for additional info.
```

Flags in `--help` provides additional information on how to use `--blockStatusCode` or `--blockRegex`:
```
--blockRegex string      Regex to detect a blocking page with the same HTTP response status code as a not blocked request
--blockStatusCode int    HTTP status code that WAF uses while blocking requests (default 403)
```

@dnkolegov please, take a look at it