### PR TITLE
Process unresolved requests as bypassed (add --ignoreUnresolved flag)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -137,7 +137,7 @@ func run(logger *log.Logger) error {
 
 	reportFile := filepath.Join(cfg.ReportPath, fmt.Sprintf("%s-%s-%s.pdf", reportPrefix, cfg.WAFName, reportSaveTime))
 
-	rows, err := db.RenderTable(reportTime, cfg.WAFName)
+	rows, err := db.RenderTable(reportTime, cfg.WAFName, true)
 	if err != nil {
 		return errors.Wrap(err, "table rendering")
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -137,12 +137,12 @@ func run(logger *log.Logger) error {
 
 	reportFile := filepath.Join(cfg.ReportPath, fmt.Sprintf("%s-%s-%s.pdf", reportPrefix, cfg.WAFName, reportSaveTime))
 
-	rows, err := db.RenderTable(reportTime, cfg.WAFName, true)
+	rows, err := db.RenderTable(reportTime, cfg.WAFName, cfg.IgnoreUnresolved)
 	if err != nil {
 		return errors.Wrap(err, "table rendering")
 	}
 
-	err = db.ExportToPDF(reportFile, reportTime, cfg.WAFName, cfg.URL, rows)
+	err = db.ExportToPDF(reportFile, reportTime, cfg.WAFName, cfg.URL, rows, cfg.IgnoreUnresolved)
 	if err != nil {
 		return errors.Wrap(err, "PDF exporting")
 	}
@@ -187,6 +187,7 @@ func parseFlags() {
 	flag.String("reportPath", reportPath, "A directory to store reports")
 	flag.String("testCasesPath", testCasesPath, "Path to a folder with test cases")
 	flag.String("wafName", wafName, "Name of the WAF product")
+	flag.Bool("ignoreUnresolved", false, "If true, unresolved test cases will be considered as bypassed (affect score and results)")
 	flag.Parse()
 }
 

--- a/internal/data/config/config.go
+++ b/internal/data/config/config.go
@@ -26,4 +26,5 @@ type Config struct {
 	TestCasesPath      string            `mapstructure:"testCasesPath"`
 	TestSet            string            `mapstructure:"testSet"`
 	WAFName            string            `mapstructure:"wafName"`
+	IgnoreUnresolved   bool				 `mapstructure:"ignoreUnresolved"`
 }

--- a/internal/data/config/config.go
+++ b/internal/data/config/config.go
@@ -26,5 +26,5 @@ type Config struct {
 	TestCasesPath      string            `mapstructure:"testCasesPath"`
 	TestSet            string            `mapstructure:"testSet"`
 	WAFName            string            `mapstructure:"wafName"`
-	IgnoreUnresolved   bool				 `mapstructure:"ignoreUnresolved"`
+	IgnoreUnresolved   bool              `mapstructure:"ignoreUnresolved"`
 }

--- a/internal/data/test/database.go
+++ b/internal/data/test/database.go
@@ -12,11 +12,11 @@ type DB struct {
 	naTests     []Info
 	tests       []Case
 
-	overallPassedRate         float32
-	overallTestcasesCompleted float32
-	overallRequests           int
-	overallRequestsFailed     int
-	wafScore                  float32
+	overallPassedRequestsPercentage float32
+	overallCompletedTestCases       float32
+	overallRequests                 int
+	overallRequestsFailed           int
+	wafScore                        float32
 }
 
 func NewDB(tests []Case) *DB {

--- a/internal/data/test/database.go
+++ b/internal/data/test/database.go
@@ -14,8 +14,8 @@ type DB struct {
 
 	overallPassedRate         float32
 	overallTestcasesCompleted float32
-	overallTestsCompleted     int
-	overallTestsFailed        int
+	overallRequests           int
+	overallRequestsFailed     int
 	wafScore                  float32
 }
 

--- a/internal/data/test/pdf.go
+++ b/internal/data/test/pdf.go
@@ -136,8 +136,11 @@ func isPositiveTest(setName string) bool {
 	return strings.Contains(setName, "false")
 }
 
-func (db *DB) RenderTable(reportTime time.Time, wafName string, unresolvedAsBypassed bool) ([][]string, error) {
-	baseHeader := []string{"Test set", "Test case", "Percentage, %", "Blocked", "Bypassed", "Unresolved"}
+func (db *DB) RenderTable(reportTime time.Time, wafName string, ignoreUnresolved bool) ([][]string, error) {
+	baseHeader := []string{"Test set", "Test case", "Percentage, %", "Blocked", "Bypassed"}
+	if !ignoreUnresolved {
+		baseHeader = append(baseHeader, "Unresolved")
+	}
 
 	// Table rows to render, regular and positive cases
 	positiveTestRows := [][]string{baseHeader}
@@ -148,11 +151,16 @@ func (db *DB) RenderTable(reportTime time.Time, wafName string, unresolvedAsBypa
 	negativeRequestsNumber := make(map[string]int)
 	unresolvedRequestsNumber := make(map[string]int)
 
-	var unresolvedPositiveRequestsSum int
+	var positiveUnresolvedRequestsSum int
 	for _, unresolvedTest := range db.naTests {
-		// Check test sets like "false-pos", etc. Move them to "Positive Tests" table.
+		// If we want to count UNRESOLVED as BYPASSED, we shouldn't count UNRESOLVED at all
+		// set it to zero by default
+		if ignoreUnresolved {
+			unresolvedRequestsNumber[unresolvedTest.Case] = 0
+			continue
+		}
 		if isPositiveTest(unresolvedTest.Set) {
-			unresolvedPositiveRequestsSum++
+			positiveUnresolvedRequestsSum++
 		}
 		unresolvedRequestsNumber[unresolvedTest.Case]++
 	}
@@ -173,19 +181,23 @@ func (db *DB) RenderTable(reportTime time.Time, wafName string, unresolvedAsBypa
 		for _, testCase := range sortedTestCases {
 			unresolvedRequests := unresolvedRequestsNumber[testCase]
 			passedRequests := db.counters[testSet][testCase][true]
-			// Avoid the unresolvedRequests cases when counting failedRequests
-			failedRequests := db.counters[testSet][testCase][false] - unresolvedRequests
-			// But include the unresolvedRequests results in totalRequests score to calculate them
-			totalRequests := passedRequests + failedRequests + unresolvedRequests
+			failedRequests := db.counters[testSet][testCase][false]
+			totalRequests := passedRequests + failedRequests
+			// If we don't want to count UNRESOLVED requests as BYPASSED, we need to subtract them
+			// from failed requests (in other case we will count them as usual), and add this
+			// subtracted value to the overall requests
+			if !ignoreUnresolved {
+				failedRequests -= unresolvedRequests
+			}
+
 			totalResolvedRequests := passedRequests + failedRequests
-
-			db.overallRequests += totalRequests
-			db.overallRequestsFailed += failedRequests
-
 			var passedRequestsPercentage float32 = 0
 			if totalResolvedRequests != 0 {
 				passedRequestsPercentage = float32(passedRequests) / float32(totalResolvedRequests) * 100
 			}
+
+			db.overallRequests += totalRequests
+			db.overallRequestsFailed += failedRequests
 
 			// If positive set - move to another table (remove from general cases)
 			if isPositiveTest(testSet) {
@@ -200,8 +212,10 @@ func (db *DB) RenderTable(reportTime time.Time, wafName string, unresolvedAsBypa
 					testCase,
 					fmt.Sprintf("%.2f", passedRequestsPercentage),
 					fmt.Sprintf("%d", failedRequests),
-					fmt.Sprintf("%d", passedRequests),
-					fmt.Sprintf("%d", unresolvedRequestsNumber[testCase])}
+					fmt.Sprintf("%d", passedRequests)}
+				if !ignoreUnresolved {
+					rowAppend = append(rowAppend, fmt.Sprintf("%d", unresolvedRequestsNumber[testCase]))
+				}
 
 				positiveTestRows = append(positiveTestRows, rowAppend)
 				continue
@@ -213,20 +227,22 @@ func (db *DB) RenderTable(reportTime time.Time, wafName string, unresolvedAsBypa
 				testCase,
 				fmt.Sprintf("%.2f", passedRequestsPercentage),
 				fmt.Sprintf("%d", passedRequests),
-				fmt.Sprintf("%d", failedRequests),
-				fmt.Sprintf("%d", unresolvedRequestsNumber[testCase])}
+				fmt.Sprintf("%d", failedRequests)}
+			if !ignoreUnresolved {
+				rowAppend = append(rowAppend, fmt.Sprintf("%d", unresolvedRequestsNumber[testCase]))
+			}
 
 			negativeRequestsNumber["blocked"] += passedRequests
 			negativeRequestsNumber["bypassed"] += failedRequests
 
 			negativeTestRows = append(negativeTestRows, rowAppend)
 
-			db.overallTestcasesCompleted += 1.00
-			db.overallPassedRate += passedRequestsPercentage
+			db.overallCompletedTestCases += 1.00
+			db.overallPassedRequestsPercentage += passedRequestsPercentage
 		}
 	}
 
-	db.wafScore = db.overallPassedRate / db.overallTestcasesCompleted
+	db.wafScore = db.overallPassedRequestsPercentage / db.overallCompletedTestCases
 
 	// Create a table for regular cases (excluding positive cases)
 	fmt.Println("\nNegative Tests:")
@@ -240,24 +256,34 @@ func (db *DB) RenderTable(reportTime time.Time, wafName string, unresolvedAsBypa
 		table.SetColMinWidth(index, colMinWidth)
 	}
 
-	positiveTestsSum := positiveRequestsNumber["blocked"] + positiveRequestsNumber["bypassed"] + unresolvedPositiveRequestsSum
-	resolvedPositiveTestsSum := positiveTestsSum - unresolvedPositiveRequestsSum
-	resolvedNegativeTestsSum := db.overallRequests - len(db.naTests) - resolvedPositiveTestsSum
+	positiveRequestsSum := positiveRequestsNumber["blocked"] + positiveRequestsNumber["bypassed"] + positiveUnresolvedRequestsSum
+	negativeRequestsSum := db.overallRequests - positiveRequestsSum
 
-	negativeTestsSum := db.overallRequests - positiveTestsSum
-	unresolvedNegativeTestsSum := len(db.naTests) - unresolvedPositiveRequestsSum
+	positiveResolvedRequestsSum := positiveRequestsSum - positiveUnresolvedRequestsSum
+	negativeResolvedRequestsSum := db.overallRequests - positiveResolvedRequestsSum
+	if !ignoreUnresolved {
+		negativeResolvedRequestsSum -= len(db.naTests)
+	}
 
-	unresolvedNegativeRate := calculatePercentage(unresolvedNegativeTestsSum, negativeTestsSum)
-	blockedNegativeRate := calculatePercentage(negativeRequestsNumber["blocked"], resolvedNegativeTestsSum)
-	bypassedNegativeRate := calculatePercentage(negativeRequestsNumber["bypassed"], resolvedNegativeTestsSum)
+	var negativeUnresolvedRequestsSum int
+	if !ignoreUnresolved {
+		negativeUnresolvedRequestsSum = len(db.naTests) - positiveUnresolvedRequestsSum
+	}
 
-	table.SetFooter([]string{
+	negativeUnresolvedRequestsPercentage := calculatePercentage(negativeUnresolvedRequestsSum, negativeRequestsSum)
+	negativeResolvedBlockedRequestsPercentage := calculatePercentage(negativeRequestsNumber["blocked"], negativeResolvedRequestsSum)
+	negativeResolvedBypassedRequestsPercentage := calculatePercentage(negativeRequestsNumber["bypassed"], negativeResolvedRequestsSum)
+
+	footerNegativeTests := []string{
 		fmt.Sprintf("Date:\n%s", reportTime.Format("2006-01-02")),
 		fmt.Sprintf("WAF Name:\n%s", wafName),
 		fmt.Sprintf("WAF Average Score:\n%.2f%%", db.wafScore),
-		fmt.Sprintf("Blocked (Resolved):\n%d/%d (%.2f%%)", negativeRequestsNumber["blocked"], resolvedNegativeTestsSum, blockedNegativeRate),
-		fmt.Sprintf("Bypassed (Resolved):\n%d/%d (%.2f%%)", negativeRequestsNumber["bypassed"], resolvedNegativeTestsSum, bypassedNegativeRate),
-		fmt.Sprintf("Unresolved:\n%d/%d (%.2f%%)", unresolvedNegativeTestsSum, negativeTestsSum, unresolvedNegativeRate)})
+		fmt.Sprintf("Blocked (Resolved):\n%d/%d (%.2f%%)", negativeRequestsNumber["blocked"], negativeResolvedRequestsSum, negativeResolvedBlockedRequestsPercentage),
+		fmt.Sprintf("Bypassed (Resolved):\n%d/%d (%.2f%%)", negativeRequestsNumber["bypassed"], negativeResolvedRequestsSum, negativeResolvedBypassedRequestsPercentage)}
+	if !ignoreUnresolved {
+		footerNegativeTests = append(footerNegativeTests, fmt.Sprintf("Unresolved:\n%d/%d (%.2f%%)", negativeUnresolvedRequestsSum, negativeRequestsSum, negativeUnresolvedRequestsPercentage))
+	}
+	table.SetFooter(footerNegativeTests)
 	table.Render()
 
 	// Create a table for positive cases
@@ -272,67 +298,87 @@ func (db *DB) RenderTable(reportTime time.Time, wafName string, unresolvedAsBypa
 		posTable.SetColMinWidth(index, colMinWidth)
 	}
 
-	unresolvedPosRate := calculatePercentage(unresolvedPositiveRequestsSum, positiveTestsSum)
-	falsePosRate := calculatePercentage(positiveRequestsNumber["blocked"], resolvedPositiveTestsSum)
-	truePosRate := calculatePercentage(positiveRequestsNumber["bypassed"], resolvedPositiveTestsSum)
+	positiveUnresolvedRequestsPercentage := calculatePercentage(positiveUnresolvedRequestsSum, positiveRequestsSum)
+	positiveResolvedFalsePercentage := calculatePercentage(positiveRequestsNumber["blocked"], positiveResolvedRequestsSum)
+	positiveResolvedTruePercentage := calculatePercentage(positiveRequestsNumber["bypassed"], positiveResolvedRequestsSum)
 
-	posTable.SetFooter([]string{
+	footerPositiveTests := []string{
 		fmt.Sprintf("Date:\n%s", reportTime.Format("2006-01-02")),
 		fmt.Sprintf("WAF Name:\n%s", wafName),
-		fmt.Sprintf("WAF Positive Score:\n%.2f%%", truePosRate),
-		fmt.Sprintf("False positive (res):\n%d/%d (%.2f%%)", positiveRequestsNumber["blocked"], resolvedPositiveTestsSum, falsePosRate),
-		fmt.Sprintf("True positive (res):\n%d/%d (%.2f%%)", positiveRequestsNumber["bypassed"], resolvedPositiveTestsSum, truePosRate),
-		fmt.Sprintf("Unresolved:\n%d/%d (%.2f%%)", unresolvedPositiveRequestsSum, positiveTestsSum, unresolvedPosRate)})
+		fmt.Sprintf("WAF Positive Score:\n%.2f%%", positiveResolvedTruePercentage),
+		fmt.Sprintf("False positive (res):\n%d/%d (%.2f%%)", positiveRequestsNumber["blocked"], positiveResolvedRequestsSum, positiveResolvedFalsePercentage),
+		fmt.Sprintf("True positive (res):\n%d/%d (%.2f%%)", positiveRequestsNumber["bypassed"], positiveResolvedRequestsSum, positiveResolvedTruePercentage)}
+	if !ignoreUnresolved {
+		footerPositiveTests = append(footerPositiveTests, fmt.Sprintf("Unresolved:\n%d/%d (%.2f%%)", positiveUnresolvedRequestsSum, positiveRequestsSum, positiveUnresolvedRequestsPercentage))
+	}
+
+	posTable.SetFooter(footerPositiveTests)
 	posTable.Render()
 
 	return negativeTestRows, nil
 }
 
-func (db *DB) ExportToPDF(reportFile string, reportTime time.Time, wafName, url string, rows [][]string) error {
+func (db *DB) ExportToPDF(reportFile string, reportTime time.Time, wafName, url string, rows [][]string, ignoreUnresolved bool) error {
 	baseHeader := []string{"Payload", "Test Case", "Encoder", "Placeholder", "Status"}
 
-	maliciousRows := [][]string{baseHeader}
-	truePosRows := [][]string{baseHeader}
-	falsePosRows := [][]string{baseHeader}
+	negativeBypassRows := [][]string{baseHeader}
+	positiveTrueRows := [][]string{baseHeader}
+	positiveFalseRows := [][]string{baseHeader}
 
-	for _, failedTest := range db.failedTests {
-		payload := fmt.Sprintf("%+q", failedTest.Payload)
+	for _, failedRequest := range db.failedTests {
+		payload := fmt.Sprintf("%+q", failedRequest.Payload)
 		payload = strings.ReplaceAll(payload[1:len(payload)-1], `\"`, `"`)
 		toAppend := []string{payload,
-			failedTest.Case,
-			failedTest.Encoder,
-			failedTest.Placeholder,
-			strconv.Itoa(failedTest.ResponseStatusCode)}
-		// Failed for False Positive - blocked by the waf (bad behavior)
-		if strings.Contains(failedTest.Set, "false") {
-			falsePosRows = append(falsePosRows, toAppend)
-			// Failed for malicious payload - bypass (bad behavior)
+			failedRequest.Case,
+			failedRequest.Encoder,
+			failedRequest.Placeholder,
+			strconv.Itoa(failedRequest.ResponseStatusCode)}
+		if isPositiveTest(failedRequest.Set) {
+			positiveFalseRows = append(positiveFalseRows, toAppend)
 		} else {
-			maliciousRows = append(maliciousRows, toAppend)
+			negativeBypassRows = append(negativeBypassRows, toAppend)
 		}
 	}
 
-	for _, blockedTest := range db.passedTests {
-		payload := fmt.Sprintf("%+q", blockedTest.Payload)
+	for _, passedRequest := range db.passedTests {
+		payload := fmt.Sprintf("%+q", passedRequest.Payload)
 		payload = strings.ReplaceAll(payload[1:len(payload)-1], `\"`, `"`)
 		// Passed for false pos - bypassed (good behavior)
-		if strings.Contains(blockedTest.Set, "false") {
-			truePosRows = append(truePosRows, []string{payload,
-				blockedTest.Case,
-				blockedTest.Encoder,
-				blockedTest.Placeholder,
-				strconv.Itoa(blockedTest.ResponseStatusCode)})
+		if isPositiveTest(passedRequest.Set) {
+			positiveTrueRows = append(positiveTrueRows, []string{payload,
+				passedRequest.Case,
+				passedRequest.Encoder,
+				passedRequest.Placeholder,
+				strconv.Itoa(passedRequest.ResponseStatusCode)})
 		}
 	}
 
 	// Num (general): number of actual rows minus top header (1 line)
-	truePosNum := len(truePosRows) - 1
-	falsePosNum := len(falsePosRows) - 1
-	// Include only real bypasses, without unknown or positive cases
-	bypassesNum := len(maliciousRows) - 1
-	blockedNum := len(db.passedTests) - truePosNum
+	positiveTrueNumber := len(positiveTrueRows) - 1
+	positiveFalseNumber := len(positiveFalseRows) - 1
+	var positiveUnresolvedNumber int
+	for _, unresolvedRequest := range db.naTests {
+		if isPositiveTest(unresolvedRequest.Set) {
+			positiveUnresolvedNumber++
+		}
+	}
 
-	cols := []float64{25, 35, 30, 35, 35, 30}
+	if ignoreUnresolved {
+		for _, unresolvedRequest := range db.naTests {
+			payload := fmt.Sprintf("%+q", unresolvedRequest.Payload)
+			payload = strings.ReplaceAll(payload[1:len(payload)-1], `\"`, `"`)
+			negativeBypassRows = append(negativeBypassRows, []string{payload,
+				unresolvedRequest.Case,
+				unresolvedRequest.Encoder,
+				unresolvedRequest.Placeholder,
+				strconv.Itoa(unresolvedRequest.ResponseStatusCode)})
+		}
+	}
+
+	negativeBypassNumber := len(negativeBypassRows) - 1
+	negativeBlockedNumber := len(db.passedTests) - positiveTrueNumber
+
+	columns := []float64{25, 35, 30, 35, 35, 30}
 
 	// Title page
 	pdf := gofpdf.New("P", "mm", "A4", "")
@@ -344,19 +390,15 @@ func (db *DB) ExportToPDF(reportFile string, reportTime time.Time, wafName, url 
 
 	pdf.SetFont("Arial", "B", 12)
 	pdf.Cell(cellWidth, cellHeight, fmt.Sprintf("WAF Average Score: %.2f%%", db.wafScore))
-	pdf.SetFont("Arial", "", 12)
 	pdf.Ln(lineBreakSize / 2)
 
-	pdf.SetFont("Arial", "B", 12)
-	pdf.Cell(cellWidth, cellHeight, fmt.Sprintf("WAF Detection Score: %.2f%%", calculatePercentage(blockedNum, bypassesNum+blockedNum)))
-	pdf.SetFont("Arial", "", 12)
+	pdf.Cell(cellWidth, cellHeight, fmt.Sprintf("WAF Detection Score: %.2f%%", calculatePercentage(negativeBlockedNumber, negativeBypassNumber+negativeBlockedNumber)))
 	pdf.Ln(lineBreakSize / 2)
 
-	pdf.SetFont("Arial", "B", 12)
-	pdf.Cell(cellWidth, cellHeight, fmt.Sprintf("WAF Positive Tests Score: %.2f%%", calculatePercentage(truePosNum, truePosNum+falsePosNum)))
-	pdf.SetFont("Arial", "", 12)
+	pdf.Cell(cellWidth, cellHeight, fmt.Sprintf("WAF Positive Tests Score: %.2f%%", calculatePercentage(positiveTrueNumber, positiveTrueNumber+positiveFalseNumber)))
 	pdf.Ln(lineBreakSize)
 
+	pdf.SetFont("Arial", "", 12)
 	pdf.Cell(cellWidth, cellHeight, fmt.Sprintf("WAF Name: %s", wafName))
 	pdf.Ln(lineBreakSize / 2)
 
@@ -364,18 +406,18 @@ func (db *DB) ExportToPDF(reportFile string, reportTime time.Time, wafName, url 
 	pdf.Ln(lineBreakSize / 2)
 
 	pdf.Cell(cellWidth, cellHeight, fmt.Sprintf("WAF Testing Date: %s", reportTime.Format("02 January 2006")))
-	pdf.Ln(lineBreakSize * 1.5)
+	pdf.Ln(lineBreakSize)
 
 	currentY := pdf.GetY()
 
 	negativeChartFlow := false
 	// Show only negative chart if positive chart is not available
-	if truePosNum+falsePosNum == 0 {
+	if positiveTrueNumber+positiveFalseNumber == 0 {
 		negativeChartFlow = true
 	}
 
-	if bypassesNum+blockedNum != 0 {
-		chartBuf, err := drawChart(bypassesNum, blockedNum, bypassesNum+blockedNum, "Bypassed", "Blocked", "Detection Score")
+	if negativeBypassNumber+negativeBlockedNumber != 0 {
+		chartBuf, err := drawChart(negativeBypassNumber, negativeBlockedNumber, negativeBypassNumber+negativeBlockedNumber, "Bypassed", "Blocked", "Detection Score")
 		if err != nil {
 			return errors.Wrap(err, "Plot generation error (negative tests)")
 		}
@@ -387,8 +429,8 @@ func (db *DB) ExportToPDF(reportFile string, reportTime time.Time, wafName, url 
 				imgWd, imgHt, negativeChartFlow, "PNG", 0, "")
 		}
 	}
-	if truePosNum+falsePosNum != 0 {
-		chartFalseBuf, err := drawChart(truePosNum, falsePosNum, truePosNum+falsePosNum, "True Positive", "False Positive", "Positive Tests Score")
+	if positiveTrueNumber+positiveFalseNumber != 0 {
+		chartFalseBuf, err := drawChart(positiveTrueNumber, positiveFalseNumber, positiveTrueNumber+positiveFalseNumber, "True Positive", "False Positive", "Positive Tests Score")
 		if err != nil {
 			return errors.Wrap(err, "Plot generation error (positive tests)")
 		}
@@ -402,11 +444,12 @@ func (db *DB) ExportToPDF(reportFile string, reportTime time.Time, wafName, url 
 	}
 
 	// Num of bypasses: failed tests minus positive cases minus unknown cases
+	unresolvedRequests := db.overallRequests - negativeBypassNumber - negativeBlockedNumber - positiveTrueNumber - positiveFalseNumber
 	pdf.Cell(cellWidth, cellHeight, fmt.Sprintf("Total: %v bypasses in %v tests, %v unresolved cases / %v test cases",
-		len(maliciousRows)-1, db.overallRequests, len(db.naTests), db.overallTestcasesCompleted))
+		negativeBypassNumber, db.overallRequests, unresolvedRequests, db.overallCompletedTestCases))
 	pdf.Ln(lineBreakSize)
 
-	tableClip(pdf, cols, rows, 10)
+	tableClip(pdf, columns, rows, 10)
 
 	wallarmLogo, err := ioutil.ReadFile(fmt.Sprintf("cmd%sresources%slogo.png", string(os.PathSeparator), string(os.PathSeparator)))
 	if err != nil {
@@ -423,19 +466,19 @@ func (db *DB) ExportToPDF(reportFile string, reportTime time.Time, wafName, url 
 	pdf.Ln(lineBreakSize)
 
 	// False Positive payloads block
-	cols = []float64{100, 30, 20, 25, 15}
+	columns = []float64{100, 30, 20, 25, 15}
 
 	pdf.SetFont("Arial", "", 12)
 	pdf.Cell(
 		cellWidth,
 		cellHeight,
 		fmt.Sprintf("\n%d false positive requests identified as blocked (failed, bad behavior)",
-			len(falsePosRows)-1),
+			len(positiveFalseRows)-1),
 	)
 	pdf.Ln(lineBreakSize)
 	pdf.SetFont("Arial", "", 10)
 
-	tableClip(pdf, cols, falsePosRows, 10)
+	tableClip(pdf, columns, positiveFalseRows, 10)
 
 	// True Positive payloads block
 	pdf.SetFont("Arial", "", 12)
@@ -443,12 +486,12 @@ func (db *DB) ExportToPDF(reportFile string, reportTime time.Time, wafName, url 
 		cellWidth,
 		cellHeight,
 		fmt.Sprintf("\n%d true positive requests identified as bypassed (passed, good behavior)",
-			len(truePosRows)-1),
+			len(positiveTrueRows)-1),
 	)
 	pdf.Ln(lineBreakSize)
 	pdf.SetFont("Arial", "", 10)
 
-	tableClip(pdf, cols, truePosRows, 10)
+	tableClip(pdf, columns, positiveTrueRows, 10)
 
 	// Malicious payloads page
 	pdf.AddPage()
@@ -457,13 +500,13 @@ func (db *DB) ExportToPDF(reportFile string, reportTime time.Time, wafName, url 
 	pdf.Ln(lineBreakSize)
 
 	pdf.SetFont("Arial", "", 12)
-	pdf.Cell(cellWidth, cellHeight, fmt.Sprintf("\n%d malicious requests have bypassed the WAF", len(maliciousRows)-1))
+	pdf.Cell(cellWidth, cellHeight, fmt.Sprintf("\n%d malicious requests have bypassed the WAF", len(negativeBypassRows)-1))
 	pdf.Ln(lineBreakSize)
 
 	pdf.SetFont("Arial", "", 10)
-	tableClip(pdf, cols, maliciousRows, 10)
+	tableClip(pdf, columns, negativeBypassRows, 10)
 
-	cols = []float64{100, 30, 20, 25, 15}
+	columns = []float64{100, 30, 20, 25, 15}
 	var unresolvedRaws [][]string
 	unresolvedRaws = append(unresolvedRaws, []string{"Payload", "Test Case", "Encoder", "Placeholder", "Status"})
 	for _, naTest := range db.naTests {
@@ -478,17 +521,19 @@ func (db *DB) ExportToPDF(reportFile string, reportTime time.Time, wafName, url 
 		)
 	}
 
-	pdf.AddPage()
-	pdf.SetFont("Arial", "", 24)
-	pdf.Cell(cellWidth, cellHeight, "Unresolved Test Cases")
-	pdf.Ln(lineBreakSize)
-	pdf.SetFont("Arial", "", 12)
-	pdf.Cell(cellWidth, cellHeight, fmt.Sprintf("\n%d requests indentified as blocked and passed or as not-blocked and not-passed",
-		len(db.naTests)))
-	pdf.Ln(lineBreakSize)
-	pdf.SetFont("Arial", "", 10)
+	if !ignoreUnresolved {
+		pdf.AddPage()
+		pdf.SetFont("Arial", "", 24)
+		pdf.Cell(cellWidth, cellHeight, "Unresolved Test Cases")
+		pdf.Ln(lineBreakSize)
+		pdf.SetFont("Arial", "", 12)
+		pdf.Cell(cellWidth, cellHeight, fmt.Sprintf("\n%d requests indentified as blocked and passed or as not-blocked and not-passed",
+			len(db.naTests)))
+		pdf.Ln(lineBreakSize)
+		pdf.SetFont("Arial", "", 10)
 
-	tableClip(pdf, cols, unresolvedRaws, 10)
+		tableClip(pdf, columns, unresolvedRaws, 10)
+	}
 
 	if err = pdf.OutputFileAndClose(reportFile); err != nil {
 		return errors.Wrap(err, "PDF generation error")


### PR DESCRIPTION
This PR provides an additional option to count unresolved test cases as bypassed. 
Without this flag we will get the following results (example):
```
+-----------------------+-----------------------+-----------------------+-----------------------+-----------------------+-----------------------+
|         DATE:         |       WAF NAME:       |  WAF AVERAGE SCORE:   |  BLOCKED (RESOLVED):  | BYPASSED (RESOLVED):  |      UNRESOLVED:      |
|      2021-05-07       |        GENERIC        |        55.83%         |   381/534 (71.35%)    |   153/534 (28.65%)    |    57/591 (9.64%)     |
+-----------------------+-----------------------+-----------------------+-----------------------+-----------------------+-----------------------+
```
With this flag:
```
+-----------------------+-----------------------+-----------------------+-----------------------+-----------------------+
|         DATE:         |       WAF NAME:       |  WAF AVERAGE SCORE:   |  BLOCKED (RESOLVED):  | BYPASSED (RESOLVED):  |
|      2021-05-07       |        GENERIC        |        50.97%         |   381/591 (64.47%)    |   210/591 (35.53%)    |
+-----------------------+-----------------------+-----------------------+-----------------------+-----------------------+

```
Which means that 57 unresolved cases (153+57=210) are now considered as bypasses by the 4xx/5xx responses from the backend.

Important: this PR affects the final score in CLI table, PDFs, and basically everywhere where it's required. Also, the format of the table changed a little bit - if we want to ignore unresolved cases, this column won't be shown in the CLI table and in PDF. Also, list of unresolved cases will be ignored too from the final PDF (they will be included in bypasses, as it should be.)