### PR TITLE
Use response cookie (if present) in case of redirect (3xx)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -68,8 +68,12 @@ func run(logger *log.Logger) error {
 	logger.Println("Test cases loading finished")
 
 	db := test.NewDB(testCases)
+	httpClient, err := scanner.NewHTTPClient(cfg)
+	if err != nil {
+		return errors.Wrap(err, "HTTP client")
+	}
 
-	s := scanner.New(db, logger, cfg)
+	s := scanner.New(db, logger, cfg, httpClient)
 
 	logger.Println("Scanned URL:", cfg.URL)
 	ok, httpStatus, err := s.PreCheck(cfg.URL)

--- a/internal/scanner/http_client.go
+++ b/internal/scanner/http_client.go
@@ -23,7 +23,7 @@ type HTTPClient struct {
 	followCookies bool
 }
 
-func NewHTTPClient(cfg *config.Config) *HTTPClient {
+func NewHTTPClient(cfg *config.Config) (*HTTPClient, error) {
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: !cfg.TLSVerify},
 		IdleConnTimeout: time.Duration(cfg.IdleConnTimeout) * time.Second,
@@ -37,7 +37,10 @@ func NewHTTPClient(cfg *config.Config) *HTTPClient {
 		}
 	}
 
-	jar, _ := cookiejar.New(nil)
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		return nil, err
+	}
 
 	cl := &http.Client{
 		Transport: tr,
@@ -59,7 +62,7 @@ func NewHTTPClient(cfg *config.Config) *HTTPClient {
 		cookies:       cfg.Cookies,
 		headers:       cfg.HTTPHeaders,
 		followCookies: cfg.FollowCookies,
-	}
+	}, nil
 }
 
 func (c *HTTPClient) Send(

--- a/internal/scanner/http_client.go
+++ b/internal/scanner/http_client.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"io/ioutil"
 	"net/http"
+	"net/http/cookiejar"
 	"net/url"
 	"time"
 
@@ -36,6 +37,8 @@ func NewHTTPClient(cfg *config.Config) *HTTPClient {
 		}
 	}
 
+	jar, _ := cookiejar.New(nil)
+
 	cl := &http.Client{
 		Transport: tr,
 		CheckRedirect: func() func(req *http.Request, via []*http.Request) error {
@@ -48,6 +51,7 @@ func NewHTTPClient(cfg *config.Config) *HTTPClient {
 				return nil
 			}
 		}(),
+		Jar: jar,
 	}
 
 	return &HTTPClient{

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -37,13 +37,13 @@ type Scanner struct {
 	wsClient   *websocket.Dialer
 }
 
-func New(db *test.DB, logger *log.Logger, cfg *config.Config) *Scanner {
+func New(db *test.DB, logger *log.Logger, cfg *config.Config, httpClient *HTTPClient) *Scanner {
 	encoder.InitEncoders()
 	return &Scanner{
 		db:         db,
 		logger:     logger,
 		cfg:        cfg,
-		httpClient: NewHTTPClient(cfg),
+		httpClient: httpClient,
 		wsClient:   websocket.DefaultDialer,
 	}
 }


### PR DESCRIPTION
This PR allows using cookies that can be received with the 3xx/redirect responses. This PR should solve the issue https://github.com/wallarm/gotestwaf/issues/57

Current problem definition: 
Gotestwaf handled cookies explicitly "by hands" in case of any response *except* redirect responses - because they got caught by `CheckRedirect` function first. Because of that, we were not able to set a response cookie if it was presented with a redirect response (redirect happened earlier).

Default HTTP client struct documentation (currently, in master branch `jar` is nil):
```
// If Jar is nil, cookies are only sent if they are explicitly
// set on the Request.
```

For example, imperva/incapsula provides cookies on the landing (redirect 3xx) page. So, in this case, we need to set cookies first and then do redirect.

So I decided to add a basic cookie jar to handle this case and other error cases.

@dnkolegov please, take a look at this