### PR TITLE
Handle connection resets and EOFs as blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,11 +139,13 @@ PDF report is ready: reports/waf-evaluation-report-generic-2021-March-03-15-15-5
 ### Configuration options
 ```
 Usage of /go/src/gotestwaf/gotestwaf:
+      --blockConnReset         If true, connection resets will be considered as block
       --blockRegex string      Regex to detect a blocking page with the same HTTP response status code as a not blocked request
       --blockStatusCode int    HTTP status code that WAF uses while blocking requests (default 403)
       --configPath string      Path to the config file (default "config.yaml")
       --followCookies          If true, use cookies sent by the server. May work only with --maxIdleConns=1
       --idleConnTimeout int    The maximum amount of time a keep-alive connection will live (default 2)
+      --ignoreUnresolved       If true, unresolved test cases will be considered as bypassed (affect score and results)
       --maxIdleConns int       The maximum number of keep-alive connections (default 2)
       --maxRedirects int       The maximum number of handling redirects (default 50)
       --nonBlockedAsPassed     If true, count requests that weren't blocked as passed. If false, requests that don't satisfy to PassStatuscode/PassRegExp as blocked

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -87,7 +87,7 @@ func run(logger *log.Logger) error {
 				ok = true
 			}
 			if errBenign != nil {
-				return errors.Wrap(err, "running benign request pre-check")
+				return errors.Wrap(errBenign, "running benign request pre-check")
 			}
 		} else {
 			return errors.Wrap(err, "running pre-check")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"log"
 	"net/url"
@@ -78,7 +79,19 @@ func run(logger *log.Logger) error {
 	logger.Println("Scanned URL:", cfg.URL)
 	ok, httpStatus, err := s.PreCheck(cfg.URL)
 	if err != nil {
-		return errors.Wrap(err, "running pre-check")
+		if cfg.BlockConnReset && (errors.Is(err, io.EOF) || errors.Is(err, syscall.ECONNRESET)) {
+			logger.Println("Connection reset, trying benign request to make sure that service is available")
+			blockedBenign, httpStatusBenign, errBenign := s.BenignPreCheck(cfg.URL)
+			if !blockedBenign {
+				logger.Printf("Service is available (HTTP status: %d), WAF resets connections. Consider this behavior as block", httpStatusBenign)
+				ok = true
+			}
+			if errBenign != nil {
+				return errors.Wrap(err, "running benign request pre-check")
+			}
+		} else {
+			return errors.Wrap(err, "running pre-check")
+		}
 	}
 	if !ok {
 		return errors.Errorf("WAF was not detected. "+
@@ -131,7 +144,7 @@ func run(logger *log.Logger) error {
 	}()
 
 	logger.Printf("Scanning %s\n", cfg.URL)
-	err = s.Run(ctx, cfg.URL)
+	err = s.Run(ctx, cfg.URL, cfg.BlockConnReset)
 	if err != nil {
 		return errors.Wrap(err, "run scanning")
 	}
@@ -192,6 +205,7 @@ func parseFlags() {
 	flag.String("testCasesPath", testCasesPath, "Path to a folder with test cases")
 	flag.String("wafName", wafName, "Name of the WAF product")
 	flag.Bool("ignoreUnresolved", false, "If true, unresolved test cases will be considered as bypassed (affect score and results)")
+	flag.Bool("blockConnReset", false, "If true, connection resets will be considered as block")
 	flag.Parse()
 }
 

--- a/internal/data/config/config.go
+++ b/internal/data/config/config.go
@@ -27,4 +27,5 @@ type Config struct {
 	TestSet            string            `mapstructure:"testSet"`
 	WAFName            string            `mapstructure:"wafName"`
 	IgnoreUnresolved   bool              `mapstructure:"ignoreUnresolved"`
+	BlockConnReset     bool              `mapstructure:"blockConnReset"`
 }


### PR DESCRIPTION
This PR provides option `--blockConnReset` to consider connection resets and EOFs as valid WAF behavior to block requests.