### PR TITLE
Fix missing key in FormBody placeholder

### DIFF
--- a/internal/payload/placeholder/formbody.go
+++ b/internal/payload/placeholder/formbody.go
@@ -12,7 +12,13 @@ func FormBody(requestURL, payload string) (*http.Request, error) {
 		return nil, err
 	}
 
-	req, err := http.NewRequest("POST", reqURL.String(), strings.NewReader(payload))
+	randomName, err := RandomHex(Seed)
+	if err != nil {
+		return nil, err
+	}
+
+	bodyPayload := randomName + "=" + payload
+	req, err := http.NewRequest("POST", reqURL.String(), strings.NewReader(bodyPayload))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fix missing key in FormBody payload (https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST#example).