### PR TITLE
Add renderToHTML flag to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ Usage of /app/gotestwaf:
       --proxy string           Proxy URL to use
       --randomDelay int        Random delay in ms in addition to the delay between requests (default 400)
       --reportPath string      A directory to store reports (default "reports")
+      --renderToHTML           If true, renders the report as an HTML file instead of PDF (default false)
       --sendDelay int          Delay in ms between requests (default 400)
       --skipWAFBlockCheck      If true, WAF detection tests will be skipped
       --testCase string        If set then only this test case will be run


### PR DESCRIPTION
Hi there, I can see there's a `--renderToHTML=true` flag we can use to get an HTML output.  https://github.com/wallarm/gotestwaf/blob/1c79bcb05a7ae7df809d8f47479895609aac09a2/internal/config/config.go#L33

This PR adds the flag to the README so that more people can benefit from it. 