### PR TITLE
Set MaxIdleConnsPerHost to same as MaxIdleConns; fixes #138

### DIFF
--- a/internal/scanner/http_client.go
+++ b/internal/scanner/http_client.go
@@ -32,9 +32,10 @@ type HTTPClient struct {
 
 func NewHTTPClient(cfg *config.Config) (*HTTPClient, error) {
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: !cfg.TLSVerify},
-		IdleConnTimeout: time.Duration(cfg.IdleConnTimeout) * time.Second,
-		MaxIdleConns:    cfg.MaxIdleConns,
+		TLSClientConfig:     &tls.Config{InsecureSkipVerify: !cfg.TLSVerify},
+		IdleConnTimeout:     time.Duration(cfg.IdleConnTimeout) * time.Second,
+		MaxIdleConns:        cfg.MaxIdleConns,
+		MaxIdleConnsPerHost: cfg.MaxIdleConns, // net.http hardcodes DefaultMaxIdleConnsPerHost to 2!
 	}
 
 	if cfg.Proxy != "" {
@@ -149,10 +150,11 @@ func (c *HTTPClient) getCookies(ctx context.Context, targetURL string) ([]*http.
 
 	sessionClient := &http.Client{
 		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: tr.TLSClientConfig.InsecureSkipVerify},
-			IdleConnTimeout: tr.IdleConnTimeout,
-			MaxIdleConns:    tr.MaxIdleConns,
-			Proxy:           tr.Proxy,
+			TLSClientConfig:     &tls.Config{InsecureSkipVerify: tr.TLSClientConfig.InsecureSkipVerify},
+			IdleConnTimeout:     tr.IdleConnTimeout,
+			MaxIdleConns:        tr.MaxIdleConns,
+			MaxIdleConnsPerHost: tr.MaxIdleConnsPerHost,
+			Proxy:               tr.Proxy,
 		},
 		CheckRedirect: redirectFunc,
 		Jar:           jar,


### PR DESCRIPTION
Without this patch, net.http limits number of idle connections to any one host to 2, so --maxIdleConns probably wasn't doing quite what it was intended to do.

Incidentally, this patch also lets you disable keepalives by passing --maxIdleConns -1.
