### PR TITLE
better testID communication

### DIFF
--- a/internal/db/export.go
+++ b/internal/db/export.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"encoding/csv"
+	"github.com/wallarm/gotestwaf/internal/helpers"
 	"os"
 	"strconv"
 
@@ -27,6 +28,7 @@ func (db *DB) ExportPayloads(payloadsExportFile string) error {
 		"Set",
 		"Case",
 		"Test Result",
+		"Test Key",
 	}); err != nil {
 		return err
 	}
@@ -54,6 +56,7 @@ func (db *DB) ExportPayloads(payloadsExportFile string) error {
 			blockedTest.Set,
 			blockedTest.Case,
 			testResult,
+			helpers.HexOfHashOfTestIdentifier(blockedTest.Set, blockedTest.Case, blockedTest.Placeholder, blockedTest.Encoder, blockedTest.Payload),
 		})
 		if err != nil {
 			return err
@@ -83,6 +86,7 @@ func (db *DB) ExportPayloads(payloadsExportFile string) error {
 			passedTest.Set,
 			passedTest.Case,
 			testResult,
+			helpers.HexOfHashOfTestIdentifier(passedTest.Set, passedTest.Case, passedTest.Placeholder, passedTest.Encoder, passedTest.Payload),
 		})
 		if err != nil {
 			return err
@@ -107,6 +111,7 @@ func (db *DB) ExportPayloads(payloadsExportFile string) error {
 			naTest.Set,
 			naTest.Case,
 			"unknown",
+			helpers.HexOfHashOfTestIdentifier(naTest.Set, naTest.Case, naTest.Placeholder, naTest.Encoder, naTest.Payload),
 		})
 		if err != nil {
 			return err

--- a/internal/helpers/HexHash.go
+++ b/internal/helpers/HexHash.go
@@ -1,0 +1,18 @@
+package helpers
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+func HexOfHashOfTestIdentifier(testSet string, testCase string, placeholder string, encoder string, payload string) string {
+	hash := sha256.New()
+	hash.Reset()
+	hash.Write([]byte(testSet))
+	hash.Write([]byte(testCase))
+	hash.Write([]byte(placeholder))
+	hash.Write([]byte(encoder))
+	hash.Write([]byte(payload))
+
+	return hex.EncodeToString(hash.Sum(nil)) // Return the hexadecimal string representation
+}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -3,8 +3,6 @@ package scanner
 import (
 	"bytes"
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"io"
 	"math/rand"
@@ -478,22 +476,12 @@ func (s *Scanner) produceTests(ctx context.Context, n int) <-chan *payloadConfig
 
 		var debugHeaderValue string
 
-		hash := sha256.New()
-
 		for _, testCase := range testCases {
 			for _, payload := range testCase.Payloads {
 				for _, encoder := range testCase.Encoders {
 					for _, placeholder := range testCase.Placeholders {
 						if s.enableDebugHeader {
-							hash.Reset()
-
-							hash.Write([]byte(testCase.Set))
-							hash.Write([]byte(testCase.Name))
-							hash.Write([]byte(placeholder.Name))
-							hash.Write([]byte(encoder))
-							hash.Write([]byte(payload))
-
-							debugHeaderValue = hex.EncodeToString(hash.Sum(nil))
+							debugHeaderValue = testCase.Set + " /// " + testCase.Name + " /// " + placeholder.Name + " /// " + encoder + " /// " + helpers.HexOfHashOfTestIdentifier(testCase.Set, testCase.Name, placeholder.Name, encoder, payload)
 						} else {
 							debugHeaderValue = ""
 						}


### PR DESCRIPTION
Per https://github.com/wallarm/gotestwaf/issues/263, passing clearer details into a WAF aids debugging. And adding more details to the CSV generated by GoTestWAF itself aids correlation after the event.