### PR TITLE
build binary and push to releases

### DIFF
--- a/.github/workflows/binary-build.yml
+++ b/.github/workflows/binary-build.yml
@@ -1,0 +1,33 @@
+name: Build binary and push to releases page
+
+on:
+  push:
+    tags:
+      - v*
+  workflow_dispatch:
+
+permissions:
+    contents: write
+    packages: write
+
+jobs:
+  releases-matrix:
+    name: Release Go Binary
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goos: [linux, darwin]
+        goarch: [amd64, arm64]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Release Client Binary
+        uses: wangyoucao577/go-release-action@v1.53
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          goos: ${{ matrix.goos }}
+          goarch: ${{ matrix.goarch }}
+          goversion: "https://dl.google.com/go/go1.23.7.linux-amd64.tar.gz"
+          project_path: cmd/gotestwaf
+          binary_name: gotestwaf
+          asset_name: "gotestwaf-${{ matrix.goos }}-${{ matrix.goarch }}"


### PR DESCRIPTION
Hi team,

create this MR to build the gotestwaf and publish the binary to releases page when new tag is created.
example of binary https://github.com/zufardhiyaulhaq/gotestwaf/releases/tag/v0.0.1

<img width="1218" alt="image" src="https://github.com/user-attachments/assets/e1627021-029f-4d18-9b96-1b3f86749363" />
